### PR TITLE
Fix async error handling

### DIFF
--- a/backend/question-service/__tests__/routes/question.routes.test.ts
+++ b/backend/question-service/__tests__/routes/question.routes.test.ts
@@ -1,10 +1,11 @@
 import { MongoDBContainer, StartedMongoDBContainer } from '@testcontainers/mongodb'
 import express, { Express } from 'express'
-
+import 'express-async-errors'
 import mongoose from 'mongoose'
 import config from '../../src/common/config.util'
 import logger from '../../src/common/logger.util'
 import connectToDatabase from '../../src/common/mongodb.util'
+import defaultErrorHandler from '../../src/middlewares/errorHandler.middleware'
 import questionRouter from '../../src/routes/question.routes'
 
 jest.mock('../../src/common/config.util', () => ({
@@ -29,6 +30,7 @@ describe('Question Routes', () => {
         app = express()
         app.use(express.json())
         app.use('/questions', questionRouter)
+        app.use(defaultErrorHandler)
 
         await connectToDatabase(connectionString)
     }, 60000)

--- a/backend/question-service/package-lock.json
+++ b/backend/question-service/package-lock.json
@@ -13,6 +13,7 @@
                 "cors": "^2.8.5",
                 "dotenv": "^16.4.5",
                 "express": "^4.21.0",
+                "express-async-errors": "^3.1.1",
                 "helmet": "^7.1.0",
                 "mongoose": "^8.6.3",
                 "winston": "^3.14.2"
@@ -3428,6 +3429,15 @@
             },
             "engines": {
                 "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/express-async-errors": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+            "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+            "license": "ISC",
+            "peerDependencies": {
+                "express": "^4.16.2"
             }
         },
         "node_modules/fast-fifo": {

--- a/backend/question-service/src/index.ts
+++ b/backend/question-service/src/index.ts
@@ -46,7 +46,7 @@ app.use((_: Request, response: Response) => {
 })
 
 // Default Error Handler
-app.use((error: Error, request: Request, response: Response) => {
+app.use((error: Error, request: Request, response: Response, _: NextFunction) => {
     logger.error(`[Controller] [${request.method}  ${request.baseUrl + request.path}] ${error.message}`)
     response.status(500).send()
 })

--- a/backend/question-service/src/index.ts
+++ b/backend/question-service/src/index.ts
@@ -3,7 +3,7 @@ import express, { Express, NextFunction, Request, Response } from 'express'
 import 'express-async-errors'
 import helmet from 'helmet'
 import passport from 'passport'
-import logger from './common/logger.util'
+import defaultErrorHandler from './middlewares/errorHandler.middleware'
 import questionRouter from './routes/question.routes'
 
 const app: Express = express()
@@ -46,9 +46,6 @@ app.use((_: Request, response: Response) => {
 })
 
 // Default Error Handler
-app.use((error: Error, request: Request, response: Response, _: NextFunction) => {
-    logger.error(`[Controller] [${request.method}  ${request.baseUrl + request.path}] ${error.message}`)
-    response.status(500).send()
-})
+app.use(defaultErrorHandler)
 
 export default app

--- a/backend/question-service/src/index.ts
+++ b/backend/question-service/src/index.ts
@@ -1,5 +1,6 @@
 import cors from 'cors'
 import express, { Express, NextFunction, Request, Response } from 'express'
+import 'express-async-errors'
 import helmet from 'helmet'
 import passport from 'passport'
 import logger from './common/logger.util'

--- a/backend/question-service/src/middlewares/errorHandler.middleware.ts
+++ b/backend/question-service/src/middlewares/errorHandler.middleware.ts
@@ -1,0 +1,16 @@
+import { NextFunction, Request, Response } from 'express'
+import mongoose from 'mongoose'
+import logger from '../common/logger.util'
+
+export default (error: Error, request: Request, response: Response, _: NextFunction) => {
+    if (error instanceof mongoose.Error.CastError) {
+        response.status(400).json('INVALID_ID').send()
+    } else if (error instanceof mongoose.Error.DocumentNotFoundError) {
+        response.status(404).json('NOT_FOUND').send()
+    } else if (error instanceof mongoose.Error.ValidationError) {
+        response.status(400).json('INVALID_DATA').send()
+    } else {
+        logger.error(`[Controller] [${request.method}  ${request.baseUrl + request.path}] ${error.message}`)
+        response.status(500).send()
+    }
+}

--- a/backend/user-service/package-lock.json
+++ b/backend/user-service/package-lock.json
@@ -14,6 +14,7 @@
                 "cors": "^2.8.5",
                 "dotenv": "^16.4.5",
                 "express": "^4.21.0",
+                "express-async-errors": "^3.1.1",
                 "helmet": "^7.1.0",
                 "jsonwebtoken": "^9.0.2",
                 "mongoose": "^8.6.3",
@@ -3764,6 +3765,15 @@
             },
             "engines": {
                 "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/express-async-errors": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+            "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+            "license": "ISC",
+            "peerDependencies": {
+                "express": "^4.16.2"
             }
         },
         "node_modules/fast-fifo": {

--- a/backend/user-service/package.json
+++ b/backend/user-service/package.json
@@ -18,6 +18,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
+        "express-async-errors": "^3.1.1",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.6.3",

--- a/backend/user-service/src/controllers/user.controller.ts
+++ b/backend/user-service/src/controllers/user.controller.ts
@@ -1,13 +1,12 @@
 import { createUser, findOneUserByEmail, findOneUserByUsername, updateUser } from '../models/user.repository'
 
-import { CreateUserDto } from '../types/CreateUserDto'
+import { ValidationError } from 'class-validator'
 import { Response } from 'express'
+import { CreateUserDto } from '../types/CreateUserDto'
 import { TypedRequest } from '../types/TypedRequest'
 import { UserDto } from '../types/UserDto'
 import { UserProfileDto } from '../types/UserProfileDto'
-import { ValidationError } from 'class-validator'
 import { hashPassword } from './auth.controller'
-import logger from '../common/logger.util'
 
 export async function handleCreateUser(request: TypedRequest<CreateUserDto>, response: Response): Promise<void> {
     const createDto = CreateUserDto.fromRequest(request)
@@ -53,11 +52,6 @@ export async function handleUpdateProfile(request: TypedRequest<UserProfileDto>,
         return
     }
 
-    try {
-        const user = await updateUser(id, createDto)
-        response.status(200).json(user).send()
-    } catch (e) {
-        logger.error(e)
-        response.status(500).json(['INVALID_USER_ID']).send()
-    }
+    const user = await updateUser(id, createDto)
+    response.status(200).json(user).send()
 }

--- a/backend/user-service/src/index.ts
+++ b/backend/user-service/src/index.ts
@@ -18,7 +18,7 @@ app.use(helmet())
 app.use(passport.initialize())
 
 // To handle CORS Errors
-app.use(async (request: Request, response: Response, next: NextFunction): Promise<void> => {
+app.use((request: Request, response: Response, next: NextFunction) => {
     response.header('Access-Control-Allow-Origin', '*') // "*" -> Allow all links to access
 
     response.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization')
@@ -38,17 +38,17 @@ app.use('/auth', authRouter)
 app.use('/users', userRouter)
 
 // Health Check Route
-app.get('/', async (_: Request, response: Response): Promise<void> => {
+app.get('/', (_: Request, response: Response) => {
     response.status(200).send()
 })
 
 //  Not Found Route
-app.use(async (_: Request, response: Response): Promise<void> => {
+app.use((_: Request, response: Response) => {
     response.status(404).send()
 })
 
 // Default Error Handler
-app.use(async (error: Error, request: Request, response: Response): Promise<void> => {
+app.use((error: Error, request: Request, response: Response, _: NextFunction) => {
     logger.error(`[Controller] [${request.method}  ${request.baseUrl + request.path}] ${error.message}`)
     response.status(500).send()
 })

--- a/backend/user-service/src/index.ts
+++ b/backend/user-service/src/index.ts
@@ -3,7 +3,7 @@ import express, { Express, NextFunction, Request, Response } from 'express'
 import 'express-async-errors'
 import helmet from 'helmet'
 import passport from 'passport'
-import logger from './common/logger.util'
+import defaultErrorHandler from './middlewares/errorHandler.middleware'
 import authRouter from './routes/auth.routes'
 import userRouter from './routes/user.routes'
 
@@ -48,9 +48,6 @@ app.use((_: Request, response: Response) => {
 })
 
 // Default Error Handler
-app.use((error: Error, request: Request, response: Response, _: NextFunction) => {
-    logger.error(`[Controller] [${request.method}  ${request.baseUrl + request.path}] ${error.message}`)
-    response.status(500).send()
-})
+app.use(defaultErrorHandler)
 
 export default app

--- a/backend/user-service/src/index.ts
+++ b/backend/user-service/src/index.ts
@@ -1,5 +1,6 @@
 import cors from 'cors'
 import express, { Express, NextFunction, Request, Response } from 'express'
+import 'express-async-errors'
 import helmet from 'helmet'
 import passport from 'passport'
 import logger from './common/logger.util'

--- a/backend/user-service/src/middlewares/errorHandler.middleware.ts
+++ b/backend/user-service/src/middlewares/errorHandler.middleware.ts
@@ -1,0 +1,16 @@
+import { NextFunction, Request, Response } from 'express'
+import mongoose from 'mongoose'
+import logger from '../common/logger.util'
+
+export default (error: Error, request: Request, response: Response, _: NextFunction) => {
+    if (error instanceof mongoose.Error.CastError) {
+        response.status(400).json('INVALID_ID').send()
+    } else if (error instanceof mongoose.Error.DocumentNotFoundError) {
+        response.status(404).json('NOT_FOUND').send()
+    } else if (error instanceof mongoose.Error.ValidationError) {
+        response.status(400).json('INVALID_DATA').send()
+    } else {
+        logger.error(`[Controller] [${request.method}  ${request.baseUrl + request.path}] ${error.message}`)
+        response.status(500).send()
+    }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
-import globals from 'globals'
 import pluginJs from '@eslint/js'
+import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default [
@@ -7,6 +7,11 @@ export default [
     { languageOptions: { globals: globals.browser } },
     pluginJs.configs.recommended,
     ...tseslint.configs.recommended,
+    {
+        rules: {
+            '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+        },
+    },
     {
         ignores: [
             '**/dist/*',

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
                 "cors": "^2.8.5",
                 "dotenv": "^16.4.5",
                 "express": "^4.21.0",
+                "express-async-errors": "^3.1.1",
                 "helmet": "^7.1.0",
                 "jsonwebtoken": "^9.0.2",
                 "mongoose": "^8.6.3",


### PR DESCRIPTION
Changelogs:
- Add express async error dependency to enable express to automatically catch async errors. Without this package, express is unable to catch errors thrown inside async handlers.
- Expand default error handler to handle mongoose errors and return specific responses with messages
- Modify existing tests to account for the new error handler

Note:
- This allows us to write cleaner code and omit the try catch blocks inside the handlers.