### PR TITLE
34 35 be question service implement put delete apis for updating and deleting questions

### DIFF
--- a/backend/question-service/__tests__/routes/question.routes.test.ts
+++ b/backend/question-service/__tests__/routes/question.routes.test.ts
@@ -2,14 +2,17 @@ import { MongoDBContainer, StartedMongoDBContainer } from '@testcontainers/mongo
 import express, { Express } from 'express'
 import 'express-async-errors'
 import mongoose from 'mongoose'
+import { agent, Agent } from 'supertest'
 import { QUESTION_BANK } from '../../__mocks__/question.mock'
-import config from '../../src/common/config.util'
 import logger from '../../src/common/logger.util'
 import connectToDatabase from '../../src/common/mongodb.util'
 import defaultErrorHandler from '../../src/middlewares/errorHandler.middleware'
 import questionSchema from '../../src/models/question.model'
 import questionRouter from '../../src/routes/question.routes'
+import { Category } from '../../src/types/Category'
+import { Complexity } from '../../src/types/Complexity'
 import { IQuestion } from '../../src/types/IQuestion'
+import { QuestionDto } from '../../src/types/QuestionDto'
 
 jest.mock('../../src/common/config.util', () => ({
     NODE_ENV: 'test',
@@ -19,6 +22,7 @@ jest.mock('../../src/common/config.util', () => ({
 
 describe('Question Routes', () => {
     let app: Express
+    let testAgent: Agent
     let startedContainer: StartedMongoDBContainer
 
     beforeAll(async () => {
@@ -28,12 +32,12 @@ describe('Question Routes', () => {
         const connectionString = `${startedContainer.getConnectionString()}?directConnection=true`
         logger.info(`[Question Routes Test] MongoDB container started on ${connectionString}`)
 
-        jest.replaceProperty(config, 'DB_URL', connectionString)
-
         app = express()
         app.use(express.json())
         app.use('/questions', questionRouter)
         app.use(defaultErrorHandler)
+
+        testAgent = agent(app)
 
         await connectToDatabase(connectionString)
     }, 60000)
@@ -46,24 +50,114 @@ describe('Question Routes', () => {
     afterEach(async () => {
         await mongoose.connection.db!.dropDatabase()
     })
-
-    // Dummy test, remove when APIs are implemented
-    it('should insert all questions', async () => {
-        await mongoose.model<IQuestion>('Question', questionSchema).bulkWrite(
-            QUESTION_BANK.map((question) => ({
-                insertOne: {
-                    document: question,
-                },
-            }))
-        )
-        const questions = await mongoose.model<IQuestion>('Question', questionSchema).find()
-        expect(questions).toHaveLength(QUESTION_BANK.length)
-    })
-
     describe('GET /questions', () => {
-        it('should return 200 OK', async () => {
-            // Dummy Test
-            expect(true).toBe(true)
+        beforeEach(async () => {
+            await mongoose.model<IQuestion>('Question', questionSchema).bulkWrite(
+                QUESTION_BANK.map((question) => ({
+                    insertOne: {
+                        document: question,
+                    },
+                }))
+            )
+            await mongoose.model<IQuestion>('Question', questionSchema).createIndexes()
+        })
+
+        it('should return 200 OK and a list of all the questions with the pagination information', async () => {
+            const queryParams = {
+                page: '1',
+                limit: '10',
+            }
+            const {
+                status,
+                body: { pagination, questions },
+            } = await testAgent.get('/questions').query(queryParams)
+            expect(status).toBe(200)
+            expect(pagination).toEqual({
+                currentPage: 1,
+                nextPage: 2,
+                totalPages: Math.ceil(QUESTION_BANK.length / 10),
+                totalItems: QUESTION_BANK.length,
+            })
+            expect(questions).toHaveLength(10)
+        })
+
+        it('should return 400 BAD REQUEST when the page or limit query parameter is not a number', async () => {
+            const queryParams = {
+                page: 'invalid',
+                limit: '10',
+            }
+            const { status } = await testAgent.get('/questions').query(queryParams)
+            expect(status).toBe(400)
+        })
+
+        it('should return 400 BAD REQUEST when the filter parameters are invalid', async () => {
+            const queryParams = {
+                page: '1',
+                limit: '10',
+                filterBy: 'invalid:invalid',
+            }
+            const { status } = await testAgent.get('/questions').query(queryParams)
+            expect(status).toBe(400)
+        })
+
+        it('should return 400 BAD REQUEST when the sort parameters are invalid', async () => {
+            const queryParams = {
+                page: '1',
+                limit: '10',
+                sortBy: 'invalid:invalid',
+            }
+            const { status } = await testAgent.get('/questions').query(queryParams)
+            expect(status).toBe(400)
+        })
+
+        it('should return 200 OK and a list of filtered questions when a valid title search parameter is provided', async () => {
+            const queryParams = {
+                page: '1',
+                limit: '20',
+                filterBy: 'title:a',
+            }
+            const {
+                status,
+                body: { questions },
+            } = await testAgent.get('/questions').query(queryParams)
+            expect(status).toBe(200)
+            expect(questions).toHaveLength(QUESTION_BANK.filter((q) => q.title.includes('a')).length)
+        })
+
+        it('should return 200 OK and a list of filtered questions when a valid filter parameter is provided', async () => {
+            const queryParams = {
+                page: '1',
+                limit: '20',
+                filterBy: 'title:a,categories:ALGORITHMS',
+            }
+            const {
+                status,
+                body: { questions },
+            } = await testAgent.get('/questions').query(queryParams)
+            expect(status).toBe(200)
+            expect(questions).toHaveLength(
+                QUESTION_BANK.filter((q) => q.title.includes('a') && q.categories.includes(Category.ALGORITHMS)).length
+            )
+        })
+
+        it('should return 200 OK and a list of sorted questions when a valid sort parameter is provided', async () => {
+            const queryParams = {
+                page: '1',
+                limit: '20',
+                sortBy: 'complexity:asc',
+            }
+            const {
+                status,
+                body: { questions },
+            } = await testAgent.get('/questions').query(queryParams)
+            expect(status).toBe(200)
+            const isSorted = questions.every(
+                (question: QuestionDto, index: number) =>
+                    index === 0 ||
+                    Object.values(Complexity).indexOf(question.complexity) >=
+                        Object.values(Complexity).indexOf(questions[index - 1].complexity)
+            )
+            expect(isSorted).toBe(true)
         })
     })
 })

--- a/backend/question-service/src/controllers/question.controller.ts
+++ b/backend/question-service/src/controllers/question.controller.ts
@@ -6,11 +6,12 @@ import {
     findQuestionCount,
 } from '../models/question.repository'
 
-import { CreateQuestionDto } from '../types/CreateQuestionDto'
-import { QuestionDto } from '../types/QuestionDto'
-import { Response } from 'express'
-import { TypedRequest } from '../types/TypedRequest'
 import { ValidationError } from 'class-validator'
+import { Response } from 'express'
+import { CreateQuestionDto } from '../types/CreateQuestionDto'
+import { IPaginationRequest } from '../types/IPaginationRequest'
+import { QuestionDto } from '../types/QuestionDto'
+import { TypedRequest } from '../types/TypedRequest'
 
 export async function handleCreateQuestion(
     request: TypedRequest<CreateQuestionDto>,
@@ -35,9 +36,9 @@ export async function handleCreateQuestion(
     response.status(201).json(dto).send()
 }
 
-export async function handleGetPaginatedQuestions(request: TypedRequest<void>, response: Response): Promise<void> {
-    const page = parseInt(request.query.page as string)
-    const limit = parseInt(request.query.limit as string)
+export async function handleGetPaginatedQuestions(request: IPaginationRequest, response: Response): Promise<void> {
+    const page = parseInt(request.query.page)
+    const limit = parseInt(request.query.limit)
 
     if (isNaN(page) || isNaN(limit) || page <= 0 || limit <= 0) {
         response.status(400).json('INVALID_PAGINATION').send()

--- a/backend/question-service/src/controllers/question.controller.ts
+++ b/backend/question-service/src/controllers/question.controller.ts
@@ -68,6 +68,8 @@ export async function handleGetPaginatedQuestions(request: IPaginationRequest, r
         response.status(400).json('INVALID_FILTER').send()
         return
     }
+    // We sort the filters so that title always comes first so that it is a prefix of either the full compound index or the categories compound index
+    filterBy.sort((a, b) => (a.at(0) === 'title' && b.at(0) !== 'title' ? -1 : 1))
 
     // We should probably do singleton pattern for question repository and implement method overloading...
     let count: number

--- a/backend/question-service/src/models/question.model.ts
+++ b/backend/question-service/src/models/question.model.ts
@@ -35,11 +35,11 @@ const questionSchema = new Schema<IQuestion>(
     }
 )
 
-// This should cover all possible queries, but we should narrow down our query patterns to remove unncesessary indexes
+// This should cover most possible queries, note that text indexes cannot include multikey indexes, so we need to create separate indexes for title and categories
 
-// Full index to support all possible queries, including prefixes where we filter by title and title + categories
-questionSchema.index({ title: 'text', categories: 1, complexity: 1 })
-// Index to support search by categories and sorting by complexity, including prefixes where we filter by categories only
+// Index to support text search by title and sorting by complexity
+questionSchema.index({ title: 'text', complexity: 1 })
+// Index to support filter by categories and sorting by complexity, including prefixes where we filter by categories only
 questionSchema.index({ categories: 1, complexity: 1 })
 // Index to support sorting by complexity only
 questionSchema.index({ complexity: 1 })

--- a/backend/question-service/src/models/question.model.ts
+++ b/backend/question-service/src/models/question.model.ts
@@ -1,7 +1,7 @@
+import { Schema } from 'mongoose'
 import { Category } from '../types/Category'
 import { Complexity } from '../types/Complexity'
 import { IQuestion } from '../types/IQuestion'
-import { Schema } from 'mongoose'
 
 const questionSchema = new Schema<IQuestion>(
     {
@@ -35,6 +35,13 @@ const questionSchema = new Schema<IQuestion>(
     }
 )
 
+// This should cover all possible queries, but we should narrow down our query patterns to remove unncesessary indexes
+
+// Full index to support all possible queries, including prefixes where we filter by title and title + categories
 questionSchema.index({ title: 'text', categories: 1, complexity: 1 })
+// Index to support search by categories and sorting by complexity, including prefixes where we filter by categories only
+questionSchema.index({ categories: 1, complexity: 1 })
+// Index to support sorting by complexity only
+questionSchema.index({ complexity: 1 })
 
 export default questionSchema

--- a/backend/question-service/src/models/question.model.ts
+++ b/backend/question-service/src/models/question.model.ts
@@ -21,8 +21,43 @@ const questionSchema = new Schema<IQuestion>(
         },
         complexity: {
             type: String,
-            enum: Object.values(Complexity),
+            enum: Object.values(Complexity).map((value: Complexity): string => {
+                switch (value) {
+                    case Complexity.EASY:
+                        return `1${value}`
+                    case Complexity.MEDIUM:
+                        return `2${value}`
+                    case Complexity.HARD:
+                        return `3${value}`
+                    default:
+                        return `1${Complexity.EASY}`
+                }
+            }),
             required: true,
+            set: (value: Complexity): string => {
+                switch (value) {
+                    case Complexity.EASY:
+                        return `1${value}`
+                    case Complexity.MEDIUM:
+                        return `2${value}`
+                    case Complexity.HARD:
+                        return `3${value}`
+                    default:
+                        return `1${Complexity.EASY}`
+                }
+            },
+            get: (value: string): Complexity => {
+                switch (value) {
+                    case '1EASY':
+                        return Complexity.EASY
+                    case '2MEDIUM':
+                        return Complexity.MEDIUM
+                    case '3HARD':
+                        return Complexity.HARD
+                    default:
+                        return Complexity.EASY
+                }
+            },
         },
         link: {
             type: String,

--- a/backend/question-service/src/models/question.model.ts
+++ b/backend/question-service/src/models/question.model.ts
@@ -34,6 +34,7 @@ const questionSchema = new Schema<IQuestion>(
                 }
             }),
             required: true,
+            // We need to prepend a number to the enum values so that their lexicographical ordering is the same as their logical ordering when they are sorted by the index
             set: (value: Complexity): string => {
                 switch (value) {
                     case Complexity.EASY:

--- a/backend/question-service/src/models/question.repository.ts
+++ b/backend/question-service/src/models/question.repository.ts
@@ -1,4 +1,4 @@
-import { Model, model } from 'mongoose'
+import { Model, model, SortOrder } from 'mongoose'
 
 import { CreateQuestionDto } from '../types/CreateQuestionDto'
 import { IQuestion } from '../types/IQuestion'
@@ -18,8 +18,50 @@ export async function findOneQuestionByTitle(title: string): Promise<IQuestion |
     return questionModel.findOne({ title })
 }
 
+export async function findPaginatedQuestionsWithSortAndFilter(
+    start: number,
+    limit: number,
+    sortBy: string[][],
+    filterBy: string[][]
+): Promise<IQuestion[]> {
+    return questionModel
+        .find({ $and: filterBy.map(([key, value]) => ({ [key]: value })) })
+        .sort(sortBy.map(([key, order]): [string, SortOrder] => [key, order as SortOrder]))
+        .limit(limit)
+        .skip(start)
+}
+
+export async function findPaginatedQuestionsWithSort(
+    start: number,
+    limit: number,
+    sortBy: string[][]
+): Promise<IQuestion[]> {
+    return questionModel
+        .find()
+        .sort(sortBy.map(([key, order]): [string, SortOrder] => [key, order as SortOrder]))
+        .limit(limit)
+        .skip(start)
+}
+
+export async function findPaginatedQuestionsWithFilter(
+    start: number,
+    limit: number,
+    filterBy: string[][]
+): Promise<IQuestion[]> {
+    return questionModel
+        .find({ $and: filterBy.map(([key, value]) => ({ [key]: value })) })
+        .limit(limit)
+        .skip(start)
+}
+
 export async function findPaginatedQuestions(start: number, limit: number): Promise<IQuestion[]> {
     return questionModel.find().limit(limit).skip(start)
+}
+
+export async function findQuestionCountWithFilter(filterBy: string[][]): Promise<number> {
+    return questionModel.countDocuments({
+        $and: filterBy.map(([key, value]) => ({ [key]: value })),
+    })
 }
 
 export async function findQuestionCount(): Promise<number> {

--- a/backend/question-service/src/routes/question.routes.ts
+++ b/backend/question-service/src/routes/question.routes.ts
@@ -1,7 +1,9 @@
 import {
     handleCreateQuestion,
+    handleDeleteQuestion,
     handleGetPaginatedQuestions,
     handleGetQuestionById,
+    handleUpdateQuestion,
 } from '../controllers/question.controller'
 
 import { Router } from 'express'
@@ -11,5 +13,7 @@ const router = Router()
 router.get('/', handleGetPaginatedQuestions)
 router.get('/:id', handleGetQuestionById)
 router.post('/', handleCreateQuestion)
+router.put('/:id', handleUpdateQuestion)
+router.delete('/:id', handleDeleteQuestion)
 
 export default router

--- a/backend/question-service/src/types/IPaginationRequest.ts
+++ b/backend/question-service/src/types/IPaginationRequest.ts
@@ -13,5 +13,7 @@ export interface IPaginationRequest
     query: {
         page: string
         limit: string
+        sortBy: string
+        filterBy: string
     }
 }

--- a/backend/question-service/src/types/IPaginationRequest.ts
+++ b/backend/question-service/src/types/IPaginationRequest.ts
@@ -13,7 +13,7 @@ export interface IPaginationRequest
     query: {
         page: string
         limit: string
-        sortBy: string
-        filterBy: string
+        sortBy: string | undefined
+        filterBy: string | undefined
     }
 }

--- a/backend/question-service/src/types/IPaginationRequest.ts
+++ b/backend/question-service/src/types/IPaginationRequest.ts
@@ -1,0 +1,17 @@
+import { Request } from 'express'
+
+export interface IPaginationRequest
+    extends Request<
+        object,
+        object,
+        object,
+        {
+            page: string
+            limit: string
+        }
+    > {
+    query: {
+        page: string
+        limit: string
+    }
+}

--- a/backend/question-service/src/types/QuestionDto.ts
+++ b/backend/question-service/src/types/QuestionDto.ts
@@ -59,6 +59,10 @@ export class QuestionDto {
         return validate(this)
     }
 
+    static isValidTextSearchFilter(key: string): boolean {
+        return ['title'].includes(key)
+    }
+
     static isValidFilter(key: string): boolean {
         return ['title', 'categories'].includes(key)
     }

--- a/backend/question-service/src/types/QuestionDto.ts
+++ b/backend/question-service/src/types/QuestionDto.ts
@@ -58,4 +58,12 @@ export class QuestionDto {
     async validate(): Promise<ValidationError[]> {
         return validate(this)
     }
+
+    static isValidFilter(key: string): boolean {
+        return ['title'].includes(key)
+    }
+
+    static isValidSort(key: string, order: string): boolean {
+        return ['asc', 'desc'].includes(order) && ['categories', 'complexity'].includes(key)
+    }
 }

--- a/backend/question-service/src/types/QuestionDto.ts
+++ b/backend/question-service/src/types/QuestionDto.ts
@@ -60,10 +60,10 @@ export class QuestionDto {
     }
 
     static isValidFilter(key: string): boolean {
-        return ['title'].includes(key)
+        return ['title', 'categories'].includes(key)
     }
 
     static isValidSort(key: string, order: string): boolean {
-        return ['asc', 'desc'].includes(order) && ['categories', 'complexity'].includes(key)
+        return ['asc', 'desc'].includes(order) && ['complexity'].includes(key)
     }
 }

--- a/backend/user-service/__tests__/routes/user.routes.test.ts
+++ b/backend/user-service/__tests__/routes/user.routes.test.ts
@@ -180,9 +180,9 @@ describe('User Routes', () => {
         })
 
         describe('DELETE /users/:id', () => {
-            it('should return 200 for successful deletion', async () => {
+            it('should return 204 for successful deletion', async () => {
                 const response = await authenticatedTestAgent.delete(`/users/${user.id}`).send()
-                expect(response.status).toBe(200)
+                expect(response.status).toBe(204)
             })
             //handleAccessControl will return 403 as the id of the token does not match the id in the request
             it('should return 403 for requests with invalid ids', async () => {

--- a/backend/user-service/package-lock.json
+++ b/backend/user-service/package-lock.json
@@ -18,6 +18,7 @@
                 "helmet": "^7.1.0",
                 "jsonwebtoken": "^9.0.2",
                 "mongoose": "^8.6.3",
+                "nodemailer": "^6.9.15",
                 "passport": "^0.7.0",
                 "passport-jwt": "^4.0.1",
                 "passport-local": "^1.0.0",
@@ -33,6 +34,7 @@
                 "@types/jest": "^29.5.13",
                 "@types/jsonwebtoken": "^9.0.7",
                 "@types/node": "^22.5.5",
+                "@types/nodemailer": "^6.4.16",
                 "@types/passport": "^1.0.16",
                 "@types/passport-jwt": "^4.0.1",
                 "@types/passport-local": "^1.0.38",
@@ -1730,6 +1732,16 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.19.2"
+            }
+        },
+        "node_modules/@types/nodemailer": {
+            "version": "6.4.16",
+            "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.16.tgz",
+            "integrity": "sha512-uz6hN6Pp0upXMcilM61CoKyjT7sskBoOWpptkjjJp8jIMlTdc3xG01U7proKkXzruMS4hS0zqtHNkNPFB20rKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/passport": {
@@ -6104,6 +6116,15 @@
             "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/nodemailer": {
+            "version": "6.9.15",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.15.tgz",
+            "integrity": "sha512-AHf04ySLC6CIfuRtRiEYtGEXgRfa6INgWGluDhnxTZhHSKvrBu7lc1VVchQ0d8nPc4cFaZoPq8vkyNoZr0TpGQ==",
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
         "node_modules/nodemon": {
             "version": "3.1.4",

--- a/backend/user-service/package.json
+++ b/backend/user-service/package.json
@@ -48,6 +48,7 @@
         "nodemon": "^3.1.4",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.2"
     }
 }

--- a/backend/user-service/src/controllers/user.controller.ts
+++ b/backend/user-service/src/controllers/user.controller.ts
@@ -7,15 +7,15 @@ import {
     updateUser,
 } from '../models/user.repository'
 
+import { ValidationError } from 'class-validator'
+import { Response } from 'express'
+import { hashPassword } from '../common/password.util'
 import { CreateUserDto } from '../types/CreateUserDto'
 import { IUser } from '../types/IUser'
-import { Response } from 'express'
 import { TypedRequest } from '../types/TypedRequest'
 import { UserDto } from '../types/UserDto'
 import { UserPasswordDto } from '../types/UserPasswordDto'
 import { UserProfileDto } from '../types/UserProfileDto'
-import { ValidationError } from 'class-validator'
-import { hashPassword } from '../common/password.util'
 
 export async function handleCreateUser(request: TypedRequest<CreateUserDto>, response: Response): Promise<void> {
     const createDto = CreateUserDto.fromRequest(request)
@@ -60,8 +60,13 @@ export async function handleUpdateProfile(request: TypedRequest<UserProfileDto>,
         return
     }
 
-    const user = await updateUser(id, createDto)
-    response.status(200).json(user).send()
+    const updatedUser = await updateUser(id, createDto)
+    if (!updatedUser) {
+        response.status(404).send()
+        return
+    }
+    const dto = UserDto.fromModel(updatedUser)
+    response.status(200).json(dto).send()
 }
 
 export async function handleGetCurrentProfile(
@@ -97,6 +102,11 @@ export async function handleUpdatePassword(request: TypedRequest<UserPasswordDto
     const id = request.params.id
     createDto.password = await hashPassword(createDto.password)
 
-    const user = await updateUser(id, createDto)
-    response.status(200).json(user).send()
+    const updatedUser = await updateUser(id, createDto)
+    if (!updatedUser) {
+        response.status(404).send()
+        return
+    }
+    const dto = UserDto.fromModel(updatedUser)
+    response.status(200).json(dto).send()
 }

--- a/backend/user-service/src/controllers/user.controller.ts
+++ b/backend/user-service/src/controllers/user.controller.ts
@@ -87,7 +87,7 @@ export async function handleGetCurrentProfile(
 export async function handleDeleteUser(request: TypedRequest<void>, response: Response): Promise<void> {
     const id = request.params.id
     await deleteUser(id)
-    response.status(200).send()
+    response.status(204).send()
 }
 
 export async function handleUpdatePassword(request: TypedRequest<UserPasswordDto>, response: Response): Promise<void> {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
                 "lucide-react": "^0.441.0",
                 "next": "14.2.11",
                 "react": "^18",
+                "react-ace": "^12.0.0",
                 "react-dom": "^18",
                 "tailwind-merge": "^1.14.0",
                 "tailwindcss-animate": "^1.0.7"
@@ -3008,6 +3009,12 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/ace-builds": {
+            "version": "1.36.2",
+            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.2.tgz",
+            "integrity": "sha512-eqqfbGwx/GKjM/EnFu4QtQ+d2NNBu84MGgxoG8R5iyFpcVeQ4p9YlTL+ZzdEJqhdkASqoqOxCSNNGyB6lvMm+A==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/acorn": {
             "version": "8.12.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
@@ -4269,6 +4276,12 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
             "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+        },
+        "node_modules/diff-match-patch": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+            "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+            "license": "Apache-2.0"
         },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
@@ -7581,6 +7594,18 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+            "license": "MIT"
+        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -8545,7 +8570,6 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -8622,6 +8646,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-ace": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-12.0.0.tgz",
+            "integrity": "sha512-PstU6CSMfYIJknb4su2Fa0WgLXzq2ufQgR6fjcSWuGT1hGTHkBzuKw+SncV8PuLCdSJBJc1VehPhyeXlWByG/g==",
+            "license": "MIT",
+            "dependencies": {
+                "ace-builds": "^1.32.8",
+                "diff-match-patch": "^1.0.5",
+                "lodash.get": "^4.4.2",
+                "lodash.isequal": "^4.5.0",
+                "prop-types": "^15.8.1"
+            },
+            "peerDependencies": {
+                "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/react-dom": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -8637,8 +8678,7 @@
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/react-remove-scroll": {
             "version": "2.5.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,6 @@
                 "frontend",
                 "backend/*"
             ],
-            "dependencies": {
-                "class-variance-authority": "^0.7.0",
-                "clsx": "^2.1.1",
-                "lucide-react": "^0.445.0",
-                "tailwind-merge": "^2.5.2",
-                "tailwindcss-animate": "^1.0.7"
-            },
             "devDependencies": {
                 "@eslint/js": "^9.10.0",
                 "eslint": "^9.10.0",
@@ -111,7 +104,8 @@
                 "nodemon": "^3.1.4",
                 "supertest": "^7.0.0",
                 "ts-jest": "^29.2.5",
-                "ts-node": "^10.9.2"
+                "ts-node": "^10.9.2",
+                "typescript": "^5.6.2"
             }
         },
         "backend/user-service/node_modules/globals": {
@@ -9255,13 +9249,6 @@
             "version": "10.4.3",
             "license": "ISC"
         },
-        "node_modules/lucide-react": {
-            "version": "0.445.0",
-            "license": "ISC",
-            "peerDependencies": {
-                "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
-            }
-        },
         "node_modules/lz-string": {
             "version": "1.5.0",
             "dev": true,
@@ -11884,14 +11871,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/tailwind-merge": {
-            "version": "2.5.2",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/dcastil"
-            }
-        },
         "node_modules/tailwindcss": {
             "version": "3.4.12",
             "license": "MIT",
@@ -12432,6 +12411,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
             "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
             "devOptional": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -33,12 +33,5 @@
             "prettier --write --ignore-unknown"
         ]
     },
-    "packageManager": "npm@10.8.2+",
-    "dependencies": {
-        "class-variance-authority": "^0.7.0",
-        "clsx": "^2.1.1",
-        "lucide-react": "^0.445.0",
-        "tailwind-merge": "^2.5.2",
-        "tailwindcss-animate": "^1.0.7"
-    }
+    "packageManager": "npm@10.8.2+"
 }


### PR DESCRIPTION
Changelog:
- [x] Add pagination filtering and sorting
- [x] Modify schema and indexes to accomodate request patterns
- [x] Add additional tests to test pagination
- [x] Fixed user passwords being sent back to FE after update and update password
- [x] Change delete API in user to return 204 as per RESTFUL standards
- [x] Add PUT API to update a question
- [x] Add DELETE API to delete a question

Notes:
If you encounter any issues with your local database throwing errors about a text index containing an array in document, drop the database or delete the index.