### PR TITLE
feat: support cancellation of matchmaking

### DIFF
--- a/backend/matching-service/src/controllers/matching.controller.ts
+++ b/backend/matching-service/src/controllers/matching.controller.ts
@@ -23,3 +23,20 @@ export async function addUserToMatchingQueue(
     await mqConnection.sendToEntryQueue(message)
     response.status(200).send()
 }
+
+// This will change after the WS is implemented
+export async function removeUserFromMatchingQueue(
+    request: ITypedBodyRequest<UserQueueRequestDto>,
+    response: Response
+): Promise<void> {
+    const createDto = UserQueueRequestDto.fromRequest(request)
+    const errors = await createDto.validate()
+    if (errors.length) {
+        const errorMessages = errors.map((error: ValidationError) => `INVALID_${error.property.toUpperCase()}`)
+        response.status(400).json(errorMessages).send()
+        return
+    }
+
+    await mqConnection.addUserToCancelledSet(createDto.userId, createDto.timestamp)
+    response.status(200).send()
+}

--- a/backend/matching-service/src/routes/matching.routes.ts
+++ b/backend/matching-service/src/routes/matching.routes.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express'
 import passport from 'passport'
-import { addUserToMatchingQueue } from '../controllers/matching.controller'
+import { addUserToMatchingQueue, removeUserFromMatchingQueue } from '../controllers/matching.controller'
 
 const router = Router()
 
 router.use(passport.authenticate('jwt', { session: false }))
 
 router.post('/', addUserToMatchingQueue)
+router.post('/cancel', removeUserFromMatchingQueue)
 
 export default router

--- a/backend/matching-service/src/types/IUserQueueMessage.ts
+++ b/backend/matching-service/src/types/IUserQueueMessage.ts
@@ -6,4 +6,5 @@ export interface IUserQueueMessage {
     complexity: Complexity
     topic: Category
     userId: string
+    timestamp: string
 }

--- a/backend/matching-service/src/types/UserQueueRequestDto.ts
+++ b/backend/matching-service/src/types/UserQueueRequestDto.ts
@@ -19,17 +19,22 @@ export class UserQueueRequestDto {
     @IsNotEmpty()
     userId: string
 
-    constructor(proficiency: Proficiency, complexity: Complexity, topic: Category, userId: string) {
+    @IsString()
+    @IsNotEmpty()
+    timestamp: string
+
+    constructor(proficiency: Proficiency, complexity: Complexity, topic: Category, userId: string, timestamp: string) {
         this.proficiency = proficiency
         this.complexity = complexity
         this.topic = topic
         this.userId = userId
+        this.timestamp = timestamp
     }
 
     static fromRequest({
-        body: { proficiency, complexity, topic, userId },
+        body: { proficiency, complexity, topic, userId, timestamp },
     }: ITypedBodyRequest<UserQueueRequestDto>): UserQueueRequestDto {
-        return new UserQueueRequestDto(proficiency, complexity, topic, userId)
+        return new UserQueueRequestDto(proficiency, complexity, topic, userId, timestamp)
     }
 
     async validate(): Promise<ValidationError[]> {

--- a/frontend/components/dashboard/new-session.tsx
+++ b/frontend/components/dashboard/new-session.tsx
@@ -29,6 +29,7 @@ export const NewSession = () => {
 
     const [selectedTopic, setSelectedTopic] = React.useState('')
     const [selectedComplexity, setSelectedComplexity] = React.useState('')
+    const [timestamp, setTimestamp] = React.useState('')
 
     const [modalData, setModalData] = React.useState({
         isOpen: false,
@@ -68,11 +69,13 @@ export const NewSession = () => {
         let response: { wsId: string } | undefined
 
         try {
+            setTimestamp(new Date().toISOString())
             response = await addUserToMatchmaking({
                 userId: session?.user.id ?? '',
                 proficiency: session?.user.proficiency as Proficiency,
                 complexity: selectedComplexity as Complexity,
                 topic: selectedTopic as Category,
+                timestamp: timestamp,
             })
         } catch {
             await handleFailedMatchmaking()

--- a/frontend/types/matching-api.ts
+++ b/frontend/types/matching-api.ts
@@ -5,4 +5,5 @@ export interface IPostMatching {
     proficiency: Proficiency
     complexity: Complexity
     topic: Category
+    timestamp: string
 }


### PR DESCRIPTION
Closes #107 

Scenarios Handled:

- [x] User A queues, User A cancels, User A re-queues (they should be allowed to queue again and not be blacklisted).
- [x] User A queues, User A cancels, User B queues (User A and User B should not be matched together)

Note:

Timestamp is passed from FE and is combined with userId to form the ID (this handles the first scenario mentioned as the cancellation request doesnt directly ack the message in the queue, it merely blacklists the user)

The endpoint will probably not be used after WS is implemented (it is just there for testing purposes, remove it after WS is completely integrated)
