### PR TITLE
118 be setup reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 **/.turbo
 
 **/*.tsbuildinfo
+
+/nginx/ssl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
             timeout: 10s
             retries: 3
             start_period: 10s
-    
+
     matching-db:
         container_name: matching-db
         image: mongo:8.0.0
@@ -80,8 +80,7 @@ services:
         networks:
             - backend-network
         depends_on:
-            user-db:
-                condition: service_healthy
+            - user-db
 
     user-db:
         container_name: user-db
@@ -92,12 +91,7 @@ services:
             - 'user_data:/data/db'
         networks:
             - backend-network
-        healthcheck:
-            test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
-            interval: 30s
-            timeout: 10s
-            retries: 5
-            start_period: 10s
+        command: mongod --quiet --logpath /dev/null
 
     question-service:
         container_name: question-service
@@ -117,8 +111,7 @@ services:
         networks:
             - backend-network
         depends_on:
-            question-db:
-                condition: service_healthy
+            - question-db
 
     question-db:
         container_name: question-db
@@ -129,12 +122,7 @@ services:
             - 'question_data:/data/db'
         networks:
             - backend-network
-        healthcheck:
-            test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
-            interval: 30s
-            timeout: 10s
-            retries: 5
-            start_period: 10s
+        command: mongod --quiet --logpath /dev/null
 
 volumes:
     user_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
             - SSL_KEY_FILE=/etc/nginx/ssl/server.key
             - USER_SERVICE_URL=http://user-service:3002
             - QUESTION_SERVICE_URL=http://question-service:3004
+            - MATCHING_SERVICE_URL=http://matching-service:3006
         image: nginx:1.27.2-alpine
         ports:
             - 443:443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,18 @@ services:
         container_name: reverse-proxy
         environment:
             - D=$
-            - NGINX_PORT=8080
+            - NGINX_SERVER_NAME=localhost
+            - SSL_CERT_FILE=/etc/nginx/ssl/server.crt
+            - SSL_KEY_FILE=/etc/nginx/ssl/server.key
             - USER_SERVICE_URL=http://user-service:3002
             - QUESTION_SERVICE_URL=http://question-service:3004
         image: nginx:1.27.2-alpine
         ports:
-            - 8080:8080
+            - 443:443
         restart: always
         volumes:
             - ./nginx/templates:/etc/nginx/templates
+            - ./nginx/ssl:/etc/nginx/ssl
         networks:
             - backend-network
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     reverse-proxy:
         container_name: reverse-proxy
         environment:
+            - D=$
             - NGINX_PORT=8080
             - USER_SERVICE_URL=http://user-service:3002
             - QUESTION_SERVICE_URL=http://question-service:3004

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,25 @@
 # This docker-compose file is for local development only. It is not intended to be deployed.
 
 services:
+    reverse-proxy:
+        container_name: reverse-proxy
+        environment:
+            - NGINX_PORT=8080
+            - USER_SERVICE_URL=http://user-service:3002
+            - QUESTION_SERVICE_URL=http://question-service:3004
+        image: nginx:1.27.2-alpine
+        ports:
+            - 8080:8080
+        restart: always
+        volumes:
+            - ./nginx/templates:/etc/nginx/templates
+        networks:
+            - backend-network
+        depends_on:
+            - user-service
+            - question-service
+        command: sh -c "envsubst < /etc/nginx/templates/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
+
     matching-service:
         container_name: matching-service
         environment:
@@ -17,15 +36,11 @@ services:
             context: .
             dockerfile: ./backend/matching-service/Dockerfile
         restart: always
-        ports:
-            - 3006:3006
         networks:
             - backend-network
         depends_on:
-            rabbitmq:
-                condition: service_healthy
-            matching-db:
-                condition: service_healthy
+            - rabbitmq
+            - matching-db
 
     rabbitmq:
         image: rabbitmq:4-management-alpine
@@ -38,12 +53,6 @@ services:
             - rabbitmq_log:/var/log/rabbitmq/
         networks:
             - backend-network
-        healthcheck:
-            test: rabbitmq-diagnostics -q ping
-            interval: 30s
-            timeout: 10s
-            retries: 3
-            start_period: 10s
 
     matching-db:
         container_name: matching-db
@@ -54,12 +63,6 @@ services:
             - 'matching_data:/data/db'
         networks:
             - backend-network
-        healthcheck:
-            test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
-            interval: 30s
-            timeout: 10s
-            retries: 5
-            start_period: 10s
 
     user-service:
         container_name: user-service
@@ -75,8 +78,6 @@ services:
             context: .
             dockerfile: ./backend/user-service/Dockerfile
         restart: always
-        ports:
-            - 3002:3002
         networks:
             - backend-network
         depends_on:
@@ -106,8 +107,6 @@ services:
             context: .
             dockerfile: ./backend/question-service/Dockerfile
         restart: always
-        ports:
-            - 3004:3004
         networks:
             - backend-network
         depends_on:

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -5,7 +5,14 @@ http {
   limit_req_status 429;
 
   server {
-    listen ${NGINX_PORT};
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name ${NGINX_SERVER_NAME};
+
+    ssl_certificate ${SSL_CERT_FILE};
+    ssl_certificate_key ${SSL_KEY_FILE};
+
     limit_req zone=rate_limit_zone burst=20 nodelay;
 
     proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -8,31 +8,22 @@ http {
     listen ${NGINX_PORT};
     limit_req zone=rate_limit_zone burst=20 nodelay;
 
+    proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;
+    proxy_set_header Host ${D}host;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade ${D}http_upgrade;
+    proxy_set_header Connection "upgrade";
+
     location /auth/ {
-      proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;
-      proxy_set_header Host ${D}host;
       proxy_pass ${USER_SERVICE_URL};
-      proxy_http_version 1.1;
-      proxy_set_header Upgrade ${D}http_upgrade;
-      proxy_set_header Connection "upgrade";
     }
 
     location /users/ {
-      proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;
-      proxy_set_header Host ${D}host;
       proxy_pass ${USER_SERVICE_URL};
-      proxy_http_version 1.1;
-      proxy_set_header Upgrade ${D}http_upgrade;
-      proxy_set_header Connection "upgrade";
     }
 
     location /questions/ {
-      proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;
-      proxy_set_header Host ${D}host;
       proxy_pass ${QUESTION_SERVICE_URL};
-      proxy_http_version 1.1;
-      proxy_set_header Upgrade ${D}http_upgrade;
-      proxy_set_header Connection "upgrade";
     }
 
     error_page 404 /404.json;

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -1,8 +1,12 @@
 events {}
 
 http {
+  limit_req_zone ${D}binary_remote_addr zone=rate_limit_zone:10m rate=10r/s;
+  limit_req_status 429;
+
   server {
     listen ${NGINX_PORT};
+    limit_req zone=rate_limit_zone burst=20 nodelay;
 
     location /auth/ {
       proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -5,15 +5,30 @@ http {
     listen ${NGINX_PORT};
 
     location /auth/ {
+      proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;
+      proxy_set_header Host ${D}host;
       proxy_pass ${USER_SERVICE_URL};
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade ${D}http_upgrade;
+      proxy_set_header Connection "upgrade";
     }
 
     location /users/ {
+      proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;
+      proxy_set_header Host ${D}host;
       proxy_pass ${USER_SERVICE_URL};
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade ${D}http_upgrade;
+      proxy_set_header Connection "upgrade";
     }
 
     location /questions/ {
+      proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;
+      proxy_set_header Host ${D}host;
       proxy_pass ${QUESTION_SERVICE_URL};
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade ${D}http_upgrade;
+      proxy_set_header Connection "upgrade";
     }
   }
 }

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -33,6 +33,10 @@ http {
       proxy_pass ${QUESTION_SERVICE_URL};
     }
 
+    location /matching/ {
+      proxy_pass ${MATCHING_SERVICE_URL};
+    }
+
     error_page 404 /404.json;
     location /404.json {
         return 404 '{"error":{"code":404,"message":"Not Found"}}';

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -1,0 +1,19 @@
+events {}
+
+http {
+  server {
+    listen ${NGINX_PORT};
+
+    location /auth/ {
+      proxy_pass ${USER_SERVICE_URL};
+    }
+
+    location /users/ {
+      proxy_pass ${USER_SERVICE_URL};
+    }
+
+    location /questions/ {
+      proxy_pass ${QUESTION_SERVICE_URL};
+    }
+  }
+}

--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -34,5 +34,20 @@ http {
       proxy_set_header Upgrade ${D}http_upgrade;
       proxy_set_header Connection "upgrade";
     }
+
+    error_page 404 /404.json;
+    location /404.json {
+        return 404 '{"error":{"code":404,"message":"Not Found"}}';
+    }
+
+    error_page 429 /429.json;
+    location /429.json {
+        return 429 '{"error":{"code":429,"message":"Too Many Requests"}}';
+    }
+
+    error_page 502 /502.json;
+    location /502.json {
+        return 502 '{"error":{"code":502,"message":"Bad Gateway"}}';
+    }
   }
 }


### PR DESCRIPTION
- [x] Nginx Reverse Proxy Setup (Can connect via https://localhost:443)
- [x] Rate Limiting (10 requests per second with buffer for additional 20)
- [x] SSL Termination (SSL setup is for local testing only)
- [x] Remove Verbosity of Logging (Especially for MongoDB, docker compose logs should now be much cleaner)