### PR TITLE
171 cicd change runner docker driver to docker container

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,8 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 2
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
             - name: Login to Docker Hub
               uses: docker/login-action@v3
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-    push:
-        branches: ['main']
     pull_request:
         types: [opened, synchronize]
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -24,7 +24,9 @@ services:
 
     matching-service:
         container_name: matching-service
-        image: glemenneo/cs3219-ay2425s1-project-g31-matching-service:latest
+        build:
+            context: .
+            dockerfile: ./backend/matching-service/Dockerfile
         environment:
             - NODE_ENV=development
             - PORT=3006
@@ -71,7 +73,9 @@ services:
 
     user-service:
         container_name: user-service
-        image: glemenneo/cs3219-ay2425s1-project-g31-user-service:latest
+        build:
+            context: .
+            dockerfile: ./backend/user-service/Dockerfile
         environment:
             - NODE_ENV=development
             - PORT=3002
@@ -102,7 +106,9 @@ services:
 
     question-service:
         container_name: question-service
-        image: glemenneo/cs3219-ay2425s1-project-g31-question-service:latest
+        build:
+            context: .
+            dockerfile: ./backend/question-service/Dockerfile
         environment:
             - NODE_ENV=development
             - PORT=3004


### PR DESCRIPTION
The default docker driver "docker" does not support cacheing to github actions cache. Modify the CD workflow to explicitly setup buildx with "docker-container" to enable cacheing to github actions cache.

Changelog:
- [x] Change docker driver to "docker-container"
- [x] Remove CI trigger on pushes to main
- [x] Change local docker compose to build images locally instead of pulling from dockerhub. This is to prevent architecture issues as the images are build on amd64 github action runners which might not be able to run on arm64 machines without a emulation solution.